### PR TITLE
Replace meme error page with simple template

### DIFF
--- a/templates/apology.html
+++ b/templates/apology.html
@@ -1,9 +1,13 @@
 {% extends "layout.html" %}
 
 {% block title %}
-    Apology
+    Error
 {% endblock %}
 
 {% block main %}
-    <img alt="{{ top }}" class="border" src="http://memegen.link/custom/{{ top | urlencode }}/{{ bottom | urlencode }}.jpg?alt=https://i.imgur.com/CsCgN7Ll.png" title="{{ top }}">
+    <div class="text-center py-5">
+        <h1 class="display-1 font-weight-bold text-danger">{{ top }}</h1>
+        <p class="lead mt-3">{{ bottom }}</p>
+        <a href="/" class="btn btn-outline-light mt-4">Go back home</a>
+    </div>
 {% endblock %}


### PR DESCRIPTION
Closes #2

Removes dependency on memegen.link external service. Error page now renders the status code and message directly using Bootstrap.