### PR TITLE
Move API key to environment variable

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -37,15 +37,14 @@ def login_required(f):
 
 def lookup(symbol):
     """Look up quote for symbol."""
+    api_key = os.environ.get("API_KEY")
 
-    # Contact API
     try:
-        response = requests.get(f"https://cloud-sse.iexapis.com/stable/stock/{urllib.parse.quote_plus(symbol)}/quote?token=pk_c8b9b2ccd9444bf6814d4c3f904cbd7d")
+        response = requests.get(f"https://cloud-sse.iexapis.com/stable/stock/{urllib.parse.quote_plus(symbol)}/quote?token={api_key}")
         response.raise_for_status()
     except requests.RequestException:
         return None
 
-    # Parse response
     try:
         quote = response.json()
         return {


### PR DESCRIPTION
Closes #1

Removes hardcoded IEX API key from source code. The key is now read from the `API_KEY` environment variable via `os.environ.get("API_KEY")`.

To run the app, set the variable before starting:
```
export API_KEY=your_key_here
flask run
```